### PR TITLE
Changes this.id to this.props.id to correctly set input cell ids.

### DIFF
--- a/src/comp/LoanDetails.js
+++ b/src/comp/LoanDetails.js
@@ -26,7 +26,7 @@ class LoanDetails extends React.Component {
           value={this.props.mortgage.months}
         />
 
-        <InputCell id={"interestRate_" + this.id}
+        <InputCell id={"interestRate_" + this.props.id}
           label="Annual interest rate"
           unitLabel='%'
           value={printableMonthlyInterestRate(this.props.mortgage.interestRate)}


### PR DESCRIPTION
Prior to this fix, all LoanDetails input cells would have an
id of "InterestRate_undefined".